### PR TITLE
Support renaming of webs and UTF8 in remove-method

### DIFF
--- a/lib/Foswiki/Plugins/DBIStorePlugin.pm
+++ b/lib/Foswiki/Plugins/DBIStorePlugin.pm
@@ -106,13 +106,22 @@ sub afterRenameHandler {
           . ( $newTopic || '' ) . ':'
           . ( $newa || '' ) )
       if TRACE;
-    my $oldo =
-      new Foswiki::Meta( $Foswiki::Plugins::SESSION, $oldWeb, $oldTopic );
+
+    my $oldo = 
+        new Foswiki::Meta( $Foswiki::Plugins::SESSION, $oldWeb, $oldTopic );
     my $newo =
-      new Foswiki::Meta( $Foswiki::Plugins::SESSION, $newWeb, $newTopic );
+        new Foswiki::Meta( $Foswiki::Plugins::SESSION, $newWeb, $newTopic );
+        
     Foswiki::Contrib::DBIStoreContrib::start();
-    Foswiki::Contrib::DBIStoreContrib::remove($oldo);    #, $olda );
-    Foswiki::Contrib::DBIStoreContrib::insert($newo);    #, $newa );
+    
+    if ($oldTopic) {
+        Foswiki::Contrib::DBIStoreContrib::remove($oldo);    #, $olda );
+        Foswiki::Contrib::DBIStoreContrib::insert($newo);    #, $newa );
+    } else {
+        #rename web
+        Foswiki::Contrib::DBIStoreContrib::rename($oldo, $newo);
+    }
+    
     Foswiki::Contrib::DBIStoreContrib::commit();
 }
 


### PR DESCRIPTION
Hi!

I added support for renaming of webs. If a web is renamed, the topicName in the `afterRenameHandler`will be empty and we can simply update the web-column in the topic-table.

Aside from that, the topic- and web-name in the remove-method are converted to UTF8 to support non-ascii names likewise to the insert-method.

Cheers
Markus
